### PR TITLE
T5522: Add logging for which mksquashfs syntax is being used

### DIFF
--- a/scripts/build/binary_rootfs
+++ b/scripts/build/binary_rootfs
@@ -321,6 +321,8 @@ case "${LB_CHROOT_FILESYSTEM}" in
 				fi
 
 				# Create image
+				Echo_message "Using: nice -n 17 mksquashfs chroot filesystem.squashfs ${MKSQUASHFS_OPTIONS}"
+				
 				Chroot chroot "nice -n 17 mksquashfs chroot filesystem.squashfs ${MKSQUASHFS_OPTIONS}"
 
 				rm -f chroot/excludes


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add logging for which mksquashfs syntax is being used when building VyOS.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://vyos.dev/T5522

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
build

## Proposed changes
<!--- Describe your changes in detail -->
When building VyOS then mksquashfs is being used to create the filesystem.squashfs file.

However since the syntax is compiled dynamically (by vyos-live-build/scripts/build/binary_rootfs) its hard to tell afterwards what the full syntax of mksquashfs really were to create that squashfs-file.

This adds logging to make it visible what the variable ${MKSQUASHFS_OPTIONS} ultimately ended up to be.

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
Look at the output when building VyOS.

This can also be done online:

1. Visit: https://github.com/vyos/vyos-rolling-nightly-builds/actions/

2. Click on the build where this change have been merged.

3. Click on "build-iso" under jobs to the left.

4. Click on "Build ISO" to the right.

5. In the upper right at "Search logs" type "Preparing squashfs image" and hit enter.

6. You should now see something similar to:

```
P: Preparing squashfs image...
P: This may take a while.
```

which with this change being merged it should look something like:

```
P: Preparing squashfs image...
P: This may take a while.
P: Using: nice -n 17 mksquashfs chroot filesystem.squashfs ${MKSQUASHFS_OPTIONS}
```

Example (before merge):

https://github.com/vyos/vyos-rolling-nightly-builds/actions/runs/5994053207/job/16255182905#step:8:6565

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly