### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ No standalone test suite — exercised end-to-end by `vyos-build`'s ISO assembly
 ## Conventions
 - Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev) where applicable.
 - License: GPLv3 (inherited from Debian `live-build`).
-- Maintain the upstream vendor field in `debian/control` (`Maintainer: Debian Live <debian-live@lists.debian.org>` + VyOS uploaders) — keeps the Debian heritage transparent.
+- Maintain the upstream vendor field in `debian/control` (`Maintainer: Debian Live <debian-live@lists.debian.org>`) — keeps the Debian heritage transparent. Do not replace it with VyOS-specific maintainer info.
 - Default branch: confirm via `git ls-remote --symref`; LTS-train branches may carry train-specific patches.
 
 ## Mirror relationship

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,3 @@ Mirror twin: `VyOS-Networks/vyos-live-build`. Mirror pipeline not confirmed live
 - ISO behavior changes that look like `live-build` bugs are often package-set issues handled by `vyos-build`; check there first before patching here.
 - No GitHub Actions workflows are currently configured in this repo (at the time of the most recent shallow clone), so CI verification happens implicitly via `vyos-build`'s smoketest.
 - When bumping `live-build` from upstream Debian, expect cascading regressions in `vyos-build` ISO assembly — coordinate.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos-live-build`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544949). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+## Project purpose
+VyOS fork of Debian's [`live-build`](https://wiki.debian.org/DebianLive) — the toolchain that assembles a hybrid live ISO from a Debian package set. Consumed by `vyos/vyos-build` to produce the VyOS ISO; carries VyOS-specific patches on top of Debian's `live-build` upstream.
+
+## Tech stack
+- Shell-heavy. Standard Debian `live-build` codebase: shell scripts, Perl helpers, `data/` skeleton trees, `share/` recipes, `manpages/`, `frontend/`, `examples/`.
+- Debian packaging in `debian/`. Build-depends (`debian/control`): `debhelper-compat (= 12)`, `po4a`, `gettext`.
+
+## Build / test / run
+```
+dpkg-buildpackage -uc -us -tc -b      # build the live-build .deb
+# Direct toolchain invocation usually goes through vyos/vyos-build's docker image,
+# which installs this package and calls `lb config`/`lb build`.
+```
+No standalone test suite — exercised end-to-end by `vyos-build`'s ISO assembly.
+
+## Repository layout
+- `frontend/` — `lb` user-facing CLI front-end.
+- `scripts/` — stage scripts (config, bootstrap, chroot, binary, source).
+- `share/` — recipe data (package lists, hooks, includes).
+- `data/` — base data files (e.g. flavors, locales).
+- `functions/` — shell functions library.
+- `manpages/` — man pages (po4a-translated).
+- `examples/` — example configs.
+- `debian/` — Debian packaging.
+- `Makefile` — top-level dispatcher.
+- `COPYING` — license.
+
+## Cross-repo context
+- Consumed by `vyos/vyos-build` at ISO assembly time. `vyos-build` invokes `lb config`/`lb build` inside its build container after dropping the `vyos-live-build` `.deb` in.
+- Listed indirectly in the VyOS image build chain. Not in `VyOS-Networks/vyos-build-packages/repos.toml`'s 14-package list (which is the Debian source-package set baked into VyOS itself), but is a build-time dependency of the ISO toolchain.
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev) where applicable.
+- License: GPLv3 (inherited from Debian `live-build`).
+- Maintain the upstream vendor field in `debian/control` (`Maintainer: Debian Live <debian-live@lists.debian.org>` + VyOS uploaders) — keeps the Debian heritage transparent.
+- Default branch: confirm via `git ls-remote --symref`; LTS-train branches may carry train-specific patches.
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyos-live-build`. Mirror pipeline not confirmed live for this repo. Treat `vyos/*` as canonical.
+
+## Notes for future contributors
+- This is a vendor fork. **Keep VyOS-specific deltas minimal and clearly attributed** so periodic resync with Debian upstream remains tractable.
+- ISO behavior changes that look like `live-build` bugs are often package-set issues handled by `vyos-build`; check there first before patching here.
+- No GitHub Actions workflows are currently configured in this repo (at the time of the most recent shallow clone), so CI verification happens implicitly via `vyos-build`'s smoketest.
+- When bumping `live-build` from upstream Debian, expect cascading regressions in `vyos-build` ISO assembly — coordinate.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos-live-build`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544949). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,5 +43,5 @@ Mirror twin: `VyOS-Networks/vyos-live-build`. Mirror pipeline not confirmed live
 ## Notes for future contributors
 - This is a vendor fork. **Keep VyOS-specific deltas minimal and clearly attributed** so periodic resync with Debian upstream remains tractable.
 - ISO behavior changes that look like `live-build` bugs are often package-set issues handled by `vyos-build`; check there first before patching here.
-- No GitHub Actions workflows are currently configured in this repo (at the time of the most recent shallow clone), so CI verification happens implicitly via `vyos-build`'s smoketest.
+- One GitHub Actions workflow is configured: a CLA check (`cla-check.yml`) that runs on pull requests via `vyos/vyos-cla-signatures`. Functional CI verification happens implicitly via `vyos-build`'s smoketest.
 - When bumping `live-build` from upstream Debian, expect cascading regressions in `vyos-build` ISO assembly — coordinate.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
